### PR TITLE
Add WordPress Playground Demo for Plugin from Github Repo

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/post-new.php?post_type=page",
+	"plugins": [
+		"https://github-proxy.com/proxy/?repo=land0r/mermaid-blocks"
+	],
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "url",
+				"url": "https://github-proxy.com/proxy/?repo=land0r/mermaid-blocks"
+			}
+		}
+	],
+	"preferredVersions": {
+		"php": "8.2",
+		"wp": "latest"
+	},
+	"features": {
+		"networking": true
+	},
+	"phpExtensionBundles": [
+		"kitchen-sink"
+	],
+	"login": true
+}

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,9 @@ Mermaid Blocks is a Gutenberg plugin that integrates [MermaidJS](https://mermaid
 
 This makes it easy to include **text-based diagrams** using MermaidJS syntax in the Gutenberg editor without additional tools or complex setups.
 
+[Playground Demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/land0r/mermaid-blocks/main/blueprint.json)
+
+
 ### Features:
 - Add MermaidJS diagrams via a dedicated Gutenberg block.
 - **Supported diagram types:** Flowcharts, Sequence Diagrams, Gantt Charts, Class Diagrams.


### PR DESCRIPTION
This pull request includes significant updates to the `blueprint.json` file and an enhancement to the `readme.txt` file for the Mermaid Blocks plugin. The changes focus on adding a new blueprint configuration and providing a demo link for users.

Blueprint configuration:

* [`blueprint.json`](diffhunk://#diff-e668b96a5d707415a7de0d144069d796b1a7b07f16f0ec5c484a94ee434c7c6eR1-R27): Added a new blueprint configuration file that includes schema definition, landing page URL, plugin installation steps, preferred versions for PHP and WordPress, enabled features, PHP extension bundles, and login requirement.

Documentation enhancement:

* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R18-R20): Added a Playground Demo link to the readme file to allow users to quickly access a demo of the Mermaid Blocks plugin.